### PR TITLE
cleanup and merge RUN layers to reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM python:2.7.13-alpine
 WORKDIR /root
 
 COPY start.sh /root/start.sh
-RUN apk update && apk add git libffi libffi-dev gcc g++ make openssl-dev openssl
-RUN cd /root/ && git clone https://github.com/byt3bl33d3r/CrackMapExec
-RUN cd /root/CrackMapExec && git submodule init && git submodule update --recursive
-RUN cd /root/CrackMapExec && python setup.py install
-
+RUN apk update && apk add git libffi libffi-dev gcc g++ make openssl-dev openssl && \
+    cd /root/ && git clone https://github.com/byt3bl33d3r/CrackMapExec && \
+    cd /root/CrackMapExec && git submodule init && git submodule update --recursive && \
+    python setup.py install &&  apk del git libffi-dev gcc g++ make openssl-dev && \
+    rm -rf /var/cache/apk/*
 CMD ["/bin/sh","/root/start.sh"]


### PR DESCRIPTION
Merged the `RUN` commands so they only create one layer. That way removal of stuff not needed after building cme leads to a reduction of the final image size.